### PR TITLE
Provide dummy variable name as default for "Define variable"

### DIFF
--- a/sourcewindow.cpp
+++ b/sourcewindow.cpp
@@ -382,7 +382,9 @@ void SourceEdit::contextMenuEvent(QContextMenuEvent * /* event */)
 void SourceEdit::defineVariable()
 {
     QString text = textCursor().selectedText();
-    if (text.length() == 0) return;
+    if (text.length() == 0) {
+        text = "varName";
+    }
     DefineVariableDialog *dialog = new DefineVariableDialog;
     dialog->nameEdit->setText(text);
     dialog->addressEdit->setText("&" + text);


### PR DESCRIPTION
This seems like a more user friendly alternative than silently returning if no text is selected.

I also considered simply disabling the "Define variable" menu action if no text was selected, but I thought that might be frustrating if users didn't realize they had to select text to enable the menu item.

Thoughts?